### PR TITLE
Add Safe Harbor date truncation and streamline tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_date_shift.py
+++ b/tests/test_date_shift.py
@@ -1,12 +1,6 @@
-import pathlib, sys
-
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
 import datetime as _dt
 
-from deidentify_fhir import deidentify_resource, _parse_fhir_date  # noqa: E402
+from deidentify_fhir import deidentify_resource, _parse_fhir_date
 
 
 def test_period_start_shifted():

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,11 +1,4 @@
-# Ensure project root on import path so `deidentify_fhir` module is discoverable
-import pathlib, sys, os
-
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from deidentify_fhir import pseudonymise_identifier  # noqa: E402
+from deidentify_fhir import pseudonymise_identifier
 
 
 def test_hash_deterministic():

--- a/tests/test_identifier_filter.py
+++ b/tests/test_identifier_filter.py
@@ -1,11 +1,4 @@
-import pathlib, sys
-
-# Ensure project root is importable
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from deidentify_fhir import deidentify_resource  # noqa: E402
+from deidentify_fhir import deidentify_resource
 
 
 def test_identifier_whitelist():

--- a/tests/test_safe_harbor.py
+++ b/tests/test_safe_harbor.py
@@ -1,0 +1,26 @@
+from deidentify_fhir import deidentify_resource
+
+
+def test_safe_harbor_truncates_and_preserves_years():
+    patient = {
+        "resourceType": "Patient",
+        "id": "p1",
+        "birthDate": "1985-04-12",
+    }
+    encounter = {
+        "resourceType": "Encounter",
+        "id": "e1",
+        "subject": {"reference": "Patient/p1"},
+        "period": {
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    }
+
+    deid_patient = deidentify_resource(patient, salt="s", shift_days=None, safe_harbor=True)
+    assert deid_patient["birthDate"] == "1985"
+
+    deid_encounter = deidentify_resource(encounter, salt="s", shift_days=None, safe_harbor=True)
+    assert deid_encounter["period"]["start"] == "2024"
+    assert deid_encounter["period"]["end"] == "2024"
+


### PR DESCRIPTION
## Summary
- Collapse all FHIR dates to year precision in Safe Harbor mode and disable shifting
- Skip shifting when collapsing to year in `shift_date`
- Add Safe Harbor date truncation test and simplify test imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2dab126348332a2ab2ada2b91e991