### PR TITLE
Gate FHIR date parsing to date-like keys

### DIFF
--- a/tests/test_date_shift.py
+++ b/tests/test_date_shift.py
@@ -43,3 +43,14 @@ def test_fractional_seconds_and_timezone_preserved(timestamp, offset, tz, frac):
     assert tz_shifted == tz
     assert frac_shifted == frac
     assert (dt_shifted - dt_orig).days == offset
+
+
+def test_unrelated_string_unchanged():
+    resource = {
+        "resourceType": "Observation",
+        "id": "obs",
+        "valueString": "1234",
+    }
+
+    deid = deidentify_resource(resource, salt="s", shift_days=400)
+    assert deid["valueString"] == "1234"


### PR DESCRIPTION
## Summary
- Avoid parsing arbitrary strings as dates by checking key names and a strict FHIR date regex
- Add regression test ensuring non-date strings like "1234" are unchanged

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0cc664883328c636b97a6fb1eb0