### PR TITLE
feat: allow configurable hash length

### DIFF
--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,10 +1,18 @@
 from deidentify_fhir import pseudonymise_identifier
 
 
-def test_hash_deterministic():
+def test_hash_deterministic_default_length():
     salt = "s3cr3t"
     ident = {"system": "http://hospital.example.org/mrn", "value": "12345"}
     first = pseudonymise_identifier(ident, salt)
     second = pseudonymise_identifier(ident, salt)
     assert first == second
     assert first["value"] != "12345"  # actually hashed
+    assert len(first["value"]) == 64  # full digest by default
+
+
+def test_hash_truncation():
+    salt = "s3cr3t"
+    ident = {"system": "http://hospital.example.org/mrn", "value": "12345"}
+    masked = pseudonymise_identifier(ident, salt, hash_length=16)
+    assert len(masked["value"]) == 16


### PR DESCRIPTION
## Summary
- expand `sha256_hash` to allow optional digest length and default to full 64 chars
- expose length control through `pseudonymise_identifier`
- test hashing determinism and default 64-char output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e354842c83328eeeaa6a951e3a9f