### PR TITLE
Add Safe Harbor regression test and centralize path setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+# Ensure the project root is importable in tests without per-file hacks
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))

--- a/tests/test_safe_harbor.py
+++ b/tests/test_safe_harbor.py
@@ -1,12 +1,16 @@
 from deidentify_fhir import deidentify_resource
 
 
-def test_safe_harbor_truncates_and_preserves_years():
+def test_safe_harbor_truncates_skips_shifting_and_bins_ages():
+    """Safe Harbor should collapse dates to years, ignore offsets and bin old ages."""
+
     patient = {
         "resourceType": "Patient",
         "id": "p1",
-        "birthDate": "1985-04-12",
+        # Older than 90 so should be binned to 1900
+        "birthDate": "1920-04-12",
     }
+
     encounter = {
         "resourceType": "Encounter",
         "id": "e1",
@@ -17,10 +21,12 @@ def test_safe_harbor_truncates_and_preserves_years():
         },
     }
 
-    deid_patient = deidentify_resource(patient, salt="s", shift_days=None, safe_harbor=True)
-    assert deid_patient["birthDate"] == "1985"
+    # Pass a large shift that would change the year if applied
+    deid_patient = deidentify_resource(patient, salt="s", shift_days=365, safe_harbor=True)
+    assert deid_patient["birthDate"] == "1900"
 
-    deid_encounter = deidentify_resource(encounter, salt="s", shift_days=None, safe_harbor=True)
+    deid_encounter = deidentify_resource(encounter, salt="s", shift_days=365, safe_harbor=True)
+    # Dates should be truncated to the year and unaffected by shifting
     assert deid_encounter["period"]["start"] == "2024"
     assert deid_encounter["period"]["end"] == "2024"
 


### PR DESCRIPTION
## Summary
- Route tests through `tests/conftest.py` to place the project root on `sys.path`
- Verify Safe Harbor mode truncates dates, ignores shifting, and bins ages ≥90

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e365bc6c8332afdd917d2aa60358